### PR TITLE
Update CMakeLists for C++11 and threading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(cssrpg)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 option(BUILD_WINDOWS "Build Windows plugin" OFF)
 option(BUILD_LINUX "Build Linux plugin" ON)
 set(HL2SDK_ROOT "hl2sdk/hl2sdk" CACHE PATH "Path to extracted HL2 SDK")
@@ -41,8 +44,10 @@ file(GLOB PLUGIN_SOURCES
     plugin_cssrpg/items/*.cpp
 )
 
+find_package(Threads REQUIRED)
+
 add_library(cssrpg MODULE ${PLUGIN_SOURCES})
 
-target_link_libraries(cssrpg ${TIER0_LIB} ${VSTDLIB_LIB} ${SQLITE_LIB})
+target_link_libraries(cssrpg ${TIER0_LIB} ${VSTDLIB_LIB} ${SQLITE_LIB} Threads::Threads)
 
 


### PR DESCRIPTION
## Summary
- enforce C++11 standard
- link plugin against Threads

## Testing
- `cmake .. -DBUILD_LINUX=ON`
- `cmake --build .` *(fails: interface.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888cf1d9a3c83229d88559141a5a925